### PR TITLE
Manage Oracle extension pack

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,6 @@ fixtures:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
     epel: "https://github.com/stahnma/puppet-module-epel.git"
+    wget: "https://github.com/maestrodev/puppet-wget.git"
   symlinks:
     virtualbox: "#{source_dir}"

--- a/README.markdown
+++ b/README.markdown
@@ -63,6 +63,21 @@ You can also opt to not manage the package with the `manage_package` parameter. 
 	  manage_package => false,
 	}
 
+###Extension Pack
+
+You can install Oracle's Extension Pack (adding support for USB 2.0, access to webcam, RDP and E1000 PXE ROM) like so:
+
+	class { 'virtualbox::extpack':
+	  version => '4.3.18r96516',
+	}
+
+This will download the Extension Pack from the Oracle's official webserver. You can also download the Extension Pack from your own server by specifying a custom source URL:
+
+	class { 'virtualbox::extpack':
+	  version => '4.3.20r96996',
+	  source => 'http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack',
+	}
+
 ##Development
 
 1. Fork it

--- a/lib/facter/virtualbox_extpack_version.rb
+++ b/lib/facter/virtualbox_extpack_version.rb
@@ -1,0 +1,14 @@
+Facter.add(:virtualbox_extpack_version) do
+  vboxmanage = '/usr/bin/VBoxManage'
+  setcode do
+    if File.exist? vboxmanage
+      output = Facter::Core::Execution.exec("#{vboxmanage} list extpacks")
+      version  = output[/Pack no. [0-9]+: +Oracle VM VirtualBox Extension Pack\nVersion: +([^r]+)\nRevision: +([^r]+)\nEdition: +.*/, 1]
+      revision = output[/Pack no. [0-9]+: +Oracle VM VirtualBox Extension Pack\nVersion: +([^r]+)\nRevision: +([^r]+)\nEdition: +.*/, 2]
+
+      if (version and revision)
+        "#{version}r#{revision}"
+      end
+    end
+  end
+end

--- a/manifests/extpack.pp
+++ b/manifests/extpack.pp
@@ -1,0 +1,90 @@
+# == Class: virtualbox::extpack
+#
+# This class (un)installs Oracle's VirtualBox extension pack.
+#
+# === Parameters
+#
+# [*ensure*]
+#   Set to 'present' to install extension pack. Set to 'absent' to uninstall.
+#   Defaults to 'present'
+#
+# [*version*]
+#   Full version of the Extension Pack to install. E.g. '4.3.20r96996'. This
+#   parameter is mandatory.
+#
+# [*source*]
+#   Download extension pack from the given URL. If not specified download from
+#   Oracle's official server.
+#
+class virtualbox::extpack (
+  $ensure  = $virtualbox::params::extpack_ensure,
+  $version = $virtualbox::params::extpack_version,
+  $source  = $virtualbox::params::extpack_source
+) inherits virtualbox::params {
+  validate_string($ensure)
+  validate_string($version)
+  if $source {
+    validate_string($source)
+  }
+
+  case $ensure {
+    'present': {
+      if $virtualbox::package_ensure == 'absent' {
+        fail('Cannot install extension pack without installing VirtualBox')
+      }
+      if $version !~ /[^r]+r[^r]+/ {
+        fail("'${version}' is not a valid version string!")
+      }
+
+      # install/upgrade if we do not have the requested version
+      if $::virtualbox_extpack_version != $version {
+        $ver = regsubst($version, '^([^r]+)r([^r]+)', '\1')
+        $build = regsubst($version, '^([^r]+)r([^r]+)', '\2')
+        $filename = "Oracle_VM_VirtualBox_Extension_Pack-${ver}-${build}.vbox-extpack"
+        if $source {
+          $url = $source
+        } else {
+          $url = "http://download.virtualbox.org/virtualbox/${ver}/${filename}"
+        }
+        $dl_dir = '/tmp'
+
+        wget::fetch { 'download vbox extpack':
+          source      => $url,
+          destination => "${dl_dir}/${filename}",
+        }
+
+        exec { 'install vbox extpack':
+          command => "VBoxManage extpack install --replace ${dl_dir}/${filename}",
+          path    => '/usr/local/bin:/usr/bin:/bin',
+          require => [
+            Class['virtualbox::install'],
+            Wget::Fetch['download vbox extpack'],
+          ],
+        }
+      }
+    }
+    'absent': {
+      if $::virtualbox_extpack_version {
+        exec { 'uninstall vbox extpack':
+          command => 'VBoxManage extpack uninstall "Oracle VM VirtualBox Extension Pack"',
+          path    => '/usr/local/bin:/usr/bin:/bin',
+        }
+
+        # Make sure we process uninstall request after installing VirtualBox
+        # (if VirtualBox will be installed during the same Puppet run) and
+        # before removing VirtualBox (if VirtualBox will be uninstalled during
+        # the same Puppet run)
+        if defined(Class['virtualbox::install']) {
+          if $virtualbox::package_ensure == 'absent' {
+            Exec['uninstall vbox extpack'] -> Class['virtualbox::install']
+          } else {
+            Class['virtualbox::install'] -> Exec['uninstall vbox extpack']
+          }
+        }
+      }
+    }
+    default: {
+      fail("Invalid value for attribute 'ensure'")
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,9 @@ class virtualbox::params {
   $manage_package = true
   $manage_repo = true
   $package_ensure = present
+  $extpack_ensure = present
+  $extpack_version = $::virtualbox_version
+  $extpack_source = undef
 
   case $::osfamily {
     'Debian': {

--- a/metadata.json
+++ b/metadata.json
@@ -66,6 +66,10 @@
     {
       "name": "stahnma/epel",
       "version_requirement": ">=0.0.6 <2.0.0"
+    },
+    {
+      "name": "maestrodev/wget",
+      "version_requirement": ">=1.0.0"
     }
   ]
 }

--- a/spec/classes/virtualbox__extpack_spec.rb
+++ b/spec/classes/virtualbox__extpack_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+describe 'virtualbox::extpack', :type => :class do
+  [ { :osfamily => 'Debian', :lsbdistid => 'Ubuntu', :lsbdistcodename => 'utopic' }, { :osfamily => 'RedHat', :operatingsystem => 'RedHat' } ].each do |os|
+    context "on #{os['osfamily']}" do
+      context 'when extpack needs to be installed' do
+        let(:facts) { os }
+        let(:params) { {
+          :ensure  => 'present',
+          :version => '4.3.20r96996'
+        } }
+        context 'Virtualbox not managed by Puppet' do
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://download.virtualbox.org/virtualbox/4.3.20/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+        context 'Virtualbox managed by Puppet as well' do
+          let(:pre_condition) { 'include virtualbox' }
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://download.virtualbox.org/virtualbox/4.3.20/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack').that_requires('Class[virtualbox::install]') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+      end
+
+      context 'when extpack needs to be installed from custom URL' do
+        let(:facts) { os }
+        let(:params) { {
+          :ensure  => 'present',
+          :version => '4.3.20r96996',
+          :source  => 'http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack'
+        } }
+        context 'Virtualbox not managed by Puppet' do
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+        context 'Virtualbox managed by Puppet as well' do
+          let(:pre_condition) { 'include virtualbox' }
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack').that_requires('Class[virtualbox::install]') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+      end
+
+      context 'when extpack needs update' do
+        let(:facts) { os.merge( { :virtualbox_extpack_version => '4.3.18r96516' } ) }
+        let(:params) { {
+          :ensure  => 'present',
+          :version => '4.3.20r96996'
+        } }
+        context 'Virtualbox not managed by Puppet' do
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://download.virtualbox.org/virtualbox/4.3.20/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+        context 'Virtualbox managed by Puppet as well' do
+          let(:pre_condition) { 'include virtualbox' }
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://download.virtualbox.org/virtualbox/4.3.20/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack').that_requires('Class[virtualbox::install]') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+      end
+
+      context 'when extpack needs update from custom URL' do
+        let(:facts) { os.merge( { :virtualbox_extpack_version => '4.3.18r96516' } ) }
+        let(:params) { {
+          :ensure  => 'present',
+          :version => '4.3.20r96996',
+          :source  => 'http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack'
+        } }
+        context 'Virtualbox not managed by Puppet' do
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+        context 'Virtualbox managed by Puppet as well' do
+          let(:pre_condition) { 'include virtualbox' }
+          it { should contain_wget__fetch('download vbox extpack').with_source('http://myserver.example.com/Oracle_VM_VirtualBox_Extension_Pack-4.3.20-96996.vbox-extpack') }
+          it { should contain_exec('install vbox extpack').that_requires('Class[virtualbox::install]') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+      end
+
+      context 'when extpack is already up to date' do
+        let(:facts) { os.merge( { :virtualbox_extpack_version => '4.3.20r96996' } ) }
+        let(:params) { {
+          :ensure  => 'present',    
+          :version => '4.3.20r96996'
+        } }
+        context 'Virtualbox not managed by Puppet' do
+          it { should_not contain_wget__fetch('download vbox extpack') }
+          it { should_not contain_exec('install vbox extpack') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+        context 'Virtualbox managed by Puppet as well' do
+          let(:pre_condition) { 'include virtualbox' }
+          it { should_not contain_wget__fetch('download vbox extpack') }
+          it { should_not contain_exec('install vbox extpack').that_requires('Class[virtualbox::install]') }
+          it { should_not contain_exec('uninstall vbox extpack') }
+        end
+      end
+
+      context 'when extpack needs to be removed' do
+        let(:facts) { os.merge( { :virtualbox_extpack_version => '4.3.20r96996' } ) }
+        let(:params) { {
+          :ensure  => 'absent',
+        } }
+        context 'Virtualbox not managed by Puppet' do
+          it { should_not contain_wget__fetch('download vbox extpack') }
+          it { should_not contain_exec('install vbox extpack') }
+          it { should contain_exec('uninstall vbox extpack') }
+        end
+        context 'Virtualbox managed by Puppet as well' do
+          let(:pre_condition) { 'include virtualbox' }
+          it { should_not contain_wget__fetch('download vbox extpack') }
+          it { should_not contain_exec('install vbox extpack') }
+          it { should contain_exec('uninstall vbox extpack') }
+        end
+      end
+    end
+  end
+end
+

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,6 +22,7 @@ RSpec.configure do |c|
       on host, puppet('module','install','puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','stahnma-epel'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','maestrodev-wget'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
I added support for installing/removing Oracle's extension pack.

Note that there is a small limitation though: Although the latest VirtualBox package can be installed automatically using `package_ensure => latest`, clean and fully automatic upgrades of the extension pack are not possible right now. The reasons for this are:

- We need the full version string (version + build as reported by `VBoxManage --version`) of VirtualBox to compose the download URL. However, I did not find a way to automatically determine the full version string in `virtualbox::extpack`.
- Facter cannot be used for this purpose since it runs _before_ `virtualbox::install` installs/upgrades VirtualBox but we need to know which version is installed _after_ `virtualbox::install` is finished (`VBoxManage` might not even be available while Facter is running). If installing/upgrading the extension pack one Puppet run after installing/upgrading VirtualBox is acceptable you can cheat and set the version to `$virtualbox_version`. Note that this is ugly and might leave you without a usable extension pack for 30 minutes...

Bottom line is: no automatic upgrades so far, you have to bump up the version in your manifest file manually. If you have any ideas how to work around this let me know!

Note that I'm not a Ruby programmer and not familiar with writing tests. I would appreciate if someone could help me out here ;-)