### PR TITLE
Add Support for OpenSuSE

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,5 +4,6 @@ fixtures:
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
     epel: "https://github.com/stahnma/puppet-module-epel.git"
     archive: "https://github.com/camptocamp/puppet-archive.git"
+    zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
   symlinks:
     virtualbox: "#{source_dir}"

--- a/README.markdown
+++ b/README.markdown
@@ -16,6 +16,7 @@ This module is tested with:
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 14.04
+- OpenSuSE 13.1
 
 It may work on other distros and OS versions, but these are the versions that we're targeting. If you wish to see another distro/version added to this list, so would we! PRs are welcome :)
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,7 +58,26 @@ class virtualbox::install (
         }
       }
     }
-    default: { fail("${::osfamily} is not supported by this module.") }
+    'Suse': {
+      case $::operatingsystem {
+        'OpenSuSE': {
+          if $manage_repo {
+            zypprepo { 'virtualbox':
+              baseurl     => "http://download.virtualbox.org/virtualbox/rpm/opensuse/${::lsbdistrelease}",
+              enabled     => 1,
+              autorefresh => 1,
+              name        => 'Oracle Virtual Box',
+              gpgcheck    => 0,
+            }
+            if $manage_package {
+              Zypprepo['virtualbox'] -> Package['virtualbox']
+            }
+          }
+        }
+        default: { fail("${::osfamily}/${::operatingsystem} is not supported by ${::module_name}.") }
+      }
+    }
+    default: { fail("${::osfamily} is not supported by ${::module_name}.") }
   }
 
   if $manage_package {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,8 +34,19 @@ class virtualbox::params {
         'glibc-devel'
       ]
     }
+    'Suse': {
+      $package_name = 'VirtualBox'
+      $vboxdrv_dependencies = [
+        'gcc',
+        'make',
+        'patch',
+        'kernel-source',
+        'binutils',
+        'glibc-devel',
+      ]
+    }
     default: {
-      fail("${::operatingsystem} not supported")
+      fail("${::operatingsystem} not supported by ${::module_name}")
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,12 @@
   ],
   "operatingsystem_support": [
     {
+      "operatingsystem": "OpenSuSE",
+      "operatingsystemrelease": [
+        "13.1"
+      ]
+    },
+    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
@@ -66,6 +72,10 @@
     {
       "name": "stahnma/epel",
       "version_requirement": ">=0.0.6 <2.0.0"
+    },
+    {
+      "name": "darin/zypprepo",
+      "version_requirement": ">=1.0.0 <2.0.0"
     },
     {
       "name": "camptocamp/archive",

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -12,6 +12,10 @@ describe 'virtualbox', :type => :class do
       :osfamily => 'RedHat',
       :operatingsystem => "RedHat",
       :operatingsystemrelease => '6.5',
+    }, {
+      :osfamily => 'Suse',
+      :operatingsystem => "OpenSuSE",
+      :lsbdistrelease => '13.1',
     }
   ].each do |facts|
     context "on #{facts[:osfamily]}" do
@@ -60,6 +64,26 @@ describe 'virtualbox', :type => :class do
 
         context 'when managing the repo and the kernel' do
           it { should contain_class('epel').that_comes_before('Class[virtualbox::kernel]') }
+        end
+      end
+
+      # Suse specific stuff
+      #
+      if facts[:osfamily] == 'Suse'
+        it { should contain_zypprepo('virtualbox').with_baseurl('http://download.virtualbox.org/virtualbox/rpm/opensuse/13.1') }
+
+        context 'with a custom version' do
+          let(:params) {{ 'version' => '4.2' }}
+          it { should contain_package('virtualbox').with_name('VirtualBox-4.2').with_ensure('present') }
+        end
+
+        context 'when not managing the package repository' do
+          let(:params) {{ 'manage_repo' => false }}
+          it { should_not contain_zypprepo('virtualbox') }
+        end
+
+        context 'when managing the package and the repository' do
+          it { should contain_zypprepo('virtualbox').that_comes_before('Package[virtualbox]') }
         end
       end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,6 +23,7 @@ RSpec.configure do |c|
       on host, puppet('module','install','puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','stahnma-epel'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module','install','camptocamp-archive'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module','install','darin-zypprepo'), { :acceptable_exit_codes => [0,1] }
     end
   end
 end


### PR DESCRIPTION
Tested this on an OpenSuSE 13.1, however, with a local repository,
since the boxes where it runs on, don't get out to the Internet.

Updated README, metadata.json, and added specs for the new
operatingsystem.

While there, I made use of $::module_name in the output of fail() in order to ease debugging.