### PR TITLE
Make module compatible with apt 2.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,7 +61,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=1.0.0 <3.0.0"
     },
     {
       "name": "stahnma/epel",


### PR DESCRIPTION
I don't see a reason why this module shouldn't be compatible with the new apt version 2.0.0.