### PR TITLE
Formally add support for Puppet 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ matrix:
     env: PUPPET_VERSION="~> 3.4.0"
   include:
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.7.0" PARSER="future"
+    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.7.0" PARSER="future"
+    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.7.0" PARSER="future"
+    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.7.0" PARSER="future"
+    env: PUPPET_VERSION="~> 4.0.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ matrix:
   include:
   - rvm: 1.8.7
     env: PUPPET_VERSION="~> 4.0.0"
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.1.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.4.0"
   include:
-  - rvm: 1.8.7
+  - rvm: 1.9.3
     env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 2.0.0
     env: PUPPET_VERSION="~> 4.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [Unreleased][unreleased]
 ### Changed
-- Now depends on puppetlabs/apt >=2.0.
+- Now depends on puppetlabs/apt >=2.0. This means that users of Puppet < 3.4.0 will need to manage their own repositories since puppetlabs/apt is only compatible with Puppet >= 3.4.0. This has necessitated a change in default behavior. Now, the default setting for `manage_repo` is false if the `puppetversion` fact is < 3.4.0. Unfortunately, I can't express this in the module dependencies in `metadata.json` so users will have to work around this.
 - More meaningful error messages when an operating system is not supported.
 - Changed the `rspec-puppet` upstream in `Gemfile` to pull from `rubygems.org` instead of GitHub.
 - Bound the version requirement for `camptocamp/archive` < 1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [Unreleased][unreleased]
 ### Changed
-- Now depends on puppetlabs/apt >=2.0. This means that users of Puppet < 3.4.0 will need to manage their own repositories since puppetlabs/apt is only compatible with Puppet >= 3.4.0. This has necessitated a change in default behavior. Now, the default setting for `manage_repo` is false if the `puppetversion` fact is < 3.4.0. Unfortunately, I can't express this in the module dependencies in `metadata.json` so users will have to work around this.
+- Now depends on puppetlabs/apt >=2.0. This means that users of Puppet < 3.5.0 will need to manage their own repositories since puppetlabs/apt is only compatible with Puppet >= 3.5.0. This has necessitated a change in default behavior. Now, the default setting for `manage_repo` is false if the `puppetversion` fact is < 3.5.0. Unfortunately, I can't express this in the module dependencies in `metadata.json` so users will have to work around this.
 - More meaningful error messages when an operating system is not supported.
 - Changed the `rspec-puppet` upstream in `Gemfile` to pull from `rubygems.org` instead of GitHub.
 - Bound the version requirement for `camptocamp/archive` < 1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
+### Changed
+- Now depends on puppetlabs/apt >=2.0.
+- More meaningful error messages when an operating system is not supported.
+- Changed the `rspec-puppet` upstream in `Gemfile` to pull from `rubygems.org` instead of GitHub.
+- Bound the version requirement for `camptocamp/archive` < 1.0.0.
+- Cleaned up the Beaker node sets.
+
+### Added
+- Now formally supports Puppet 4.0.
+- Added a `manage_epel` parameter so you can now disable or enable the EPEL repo separately from the VirtualBox repo.
+- Added CentOS 6.6 and 5.11 to the beaker nodesets. Updated the documentation to reflect this.
+- Experimental support for OpenSuSE added. There are plenty of caveats here, so this is not officially supported.
+
+### Removed
+- Removed future parser tests from `.travis.yml`
+- This module no longer manages the `debian-keyring` and `debian-archive-keyring` packages as part of the `apt::source` resource.
 
 ## [1.2.1] - 2015-02-07
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,26 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  gem "puppet-lint"
-  gem "rspec-puppet"
-  gem "puppet-syntax"
-  gem "puppetlabs_spec_helper"
-  gem "json"
-  gem "metadata-json-lint"
+  gem 'rake'
+  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.7.0'
+  gem 'puppet-lint'
+  # https://github.com/rspec/rspec-core/issues/1864
+  gem 'rspec', '< 3.2.0', {'platforms'=>['ruby_18']}
+  gem 'rspec-puppet'
+  gem 'puppet-syntax'
+  gem 'puppetlabs_spec_helper'
+  gem 'json'
+  gem 'metadata-json-lint'
 end
 
 group :development do
-  gem "yard"
-  gem "travis"
-  gem "travis-lint"
-  gem "beaker"
-  gem "beaker-rspec"
-  gem "vagrant-wrapper"
-  gem "puppet-blacksmith"
-  gem "guard-rake"
-  gem "pry"
+  gem 'yard'
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
+  gem 'puppet-blacksmith'
+  gem 'guard-rake'
+  gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "puppet-lint"
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git', :ref => 'v2.0.0'
+  gem "rspec-puppet"
   gem "puppet-syntax"
   gem "puppetlabs_spec_helper"
   gem "json"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,24 +274,23 @@ GEM
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retriable (1.4.1)
-    rspec (3.2.0)
-      rspec-core (~> 3.2.0)
-      rspec-expectations (~> 3.2.0)
-      rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.3)
-      rspec-support (~> 3.2.0)
-    rspec-expectations (3.2.1)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.7)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
+      rspec-support (~> 3.1.0)
     rspec-its (1.2.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.2.1)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.2.0)
+    rspec-mocks (3.1.3)
+      rspec-support (~> 3.1.0)
     rspec-puppet (2.1.0)
       rspec
-    rspec-support (3.2.2)
+    rspec-support (3.1.2)
     rsync (1.0.9)
     serverspec (2.14.1)
       multi_json
@@ -308,7 +307,7 @@ GEM
     slop (3.6.0)
     spdx-licenses (1.0.0)
       json
-    specinfra (2.30.1)
+    specinfra (2.30.2)
       net-scp
       net-ssh
     thor (0.19.1)
@@ -356,6 +355,7 @@ DEPENDENCIES
   puppet-syntax
   puppetlabs_spec_helper
   rake
+  rspec (< 3.2.0)
   rspec-puppet
   travis
   travis-lint

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,30 @@
-GIT
-  remote: https://github.com/rodjek/rspec-puppet.git
-  revision: 43fea603a5f308731e9b51337fb9adc66fa72d18
-  ref: v2.0.0
-  specs:
-    rspec-puppet (2.0.0)
-      rspec (~> 2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.0)
-    activesupport (4.2.0)
+    CFPropertyList (2.3.1)
+    activesupport (4.2.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.6)
-    archive-tar-minitar (0.5.2)
+    addressable (2.3.8)
     autoparse (0.3.3)
       addressable (>= 2.3.1)
       extlib (>= 0.9.15)
       multi_json (>= 1.0.0)
-    aws-sdk (1.61.0)
-      aws-sdk-v1 (= 1.61.0)
-    aws-sdk-v1 (1.61.0)
+    aws-sdk (1.64.0)
+      aws-sdk-v1 (= 1.64.0)
+    aws-sdk-v1 (1.64.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     backports (3.6.4)
-    beaker (2.3.0)
+    beaker (2.10.0)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)
       fog (~> 1.25)
-      google-api-client (~> 0.7)
+      google-api-client (~> 0.8)
       hocon (~> 0.0.4)
       inifile (~> 2.0)
       json (~> 1.8)
@@ -41,42 +32,47 @@ GEM
       net-scp (~> 1.2)
       net-ssh (~> 2.9)
       rbvmomi (~> 1.8)
+      rsync (~> 1.0.9)
       unf (~> 0.1)
-    beaker-rspec (4.0.0)
+    beaker-rspec (5.0.2)
       beaker (~> 2.0)
       rspec
-      serverspec (~> 1.0)
-      specinfra (~> 1.0)
+      serverspec (~> 2)
+      specinfra (~> 2)
     builder (3.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
     diff-lcs (1.2.5)
-    docker-api (1.17.0)
-      archive-tar-minitar
+    docker-api (1.21.2)
       excon (>= 0.38.0)
       json
-    ethon (0.7.2)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
+    ethon (0.7.3)
       ffi (>= 1.3.0)
-    excon (0.44.0)
+    excon (0.45.3)
     extlib (0.9.16)
     facter (1.7.6)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.1)
       faraday (>= 0.7.4, < 0.10)
-    ffi (1.9.6)
+    ffi (1.9.8)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.27.0)
+    fog (1.29.0)
       fog-atmos
       fog-aws (~> 0.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.3)
+      fog-core (~> 1.27, >= 1.27.4)
       fog-ecloud
       fog-json
+      fog-local
+      fog-powerdns (>= 0.1.1)
       fog-profitbricks
       fog-radosgw (>= 0.0.2)
+      fog-riakcs
       fog-sakuracloud (>= 0.0.4)
       fog-serverlove
       fog-softlayer
@@ -90,7 +86,7 @@ GEM
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.0.8)
+    fog-aws (0.1.2)
       fog-core (~> 1.27)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
@@ -99,48 +95,59 @@ GEM
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.28.0)
+    fog-core (1.30.0)
       builder
-      excon (~> 0.38)
+      excon (~> 0.45)
       formatador (~> 0.2)
       mime-types
       net-scp (~> 1.1)
       net-ssh (>= 2.1.3)
-    fog-ecloud (0.0.2)
+    fog-ecloud (0.1.1)
       fog-core
       fog-xml
-    fog-json (1.0.0)
+    fog-json (1.0.1)
+      fog-core (~> 1.0)
       multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
+    fog-local (0.2.1)
+      fog-core (~> 1.27)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (0.0.2)
       fog-core
       fog-xml
       nokogiri
-    fog-radosgw (0.0.3)
+    fog-radosgw (0.0.4)
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
-    fog-sakuracloud (1.0.0)
+    fog-riakcs (0.1.0)
       fog-core
       fog-json
-    fog-serverlove (0.1.1)
+      fog-xml
+    fog-sakuracloud (1.0.1)
       fog-core
       fog-json
-    fog-softlayer (0.4.0)
+    fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-storm_on_demand (0.1.0)
+    fog-softlayer (0.4.5)
       fog-core
       fog-json
-    fog-terremark (0.0.3)
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
       fog-core
       fog-xml
-    fog-vmfusion (0.0.1)
+    fog-vmfusion (0.1.0)
       fission
       fog-core
-    fog-voxel (0.0.2)
+    fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-xml (0.1.1)
+    fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
@@ -151,17 +158,25 @@ GEM
       multi_json (~> 1.0)
       net-http-persistent (>= 2.7)
       net-http-pipeline
-    google-api-client (0.8.2)
+    google-api-client (0.8.6)
       activesupport (>= 3.2)
       addressable (~> 2.3)
       autoparse (~> 0.3)
       extlib (~> 0.9)
       faraday (~> 0.9)
+      googleauth (~> 0.3)
       launchy (~> 2.4)
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    guard (2.11.1)
+    googleauth (0.4.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (= 1.11)
+      signet (~> 0.6)
+    guard (2.12.5)
       formatador (>= 0.2.4)
       listen (~> 2.7)
       lumberjack (~> 1.0)
@@ -175,34 +190,41 @@ GEM
       rake
     hiera (1.3.4)
       json_pure
-    highline (1.6.21)
+    highline (1.7.2)
     hitimes (1.2.2)
     hocon (0.0.7)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     inflecto (0.0.2)
     inifile (2.0.2)
     ipaddress (0.8.0)
     json (1.8.2)
     json_pure (1.8.2)
-    jwt (1.2.1)
+    jwt (1.4.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    listen (2.8.5)
-      celluloid (>= 0.15.2)
+    listen (2.10.0)
+      celluloid (~> 0.16.0)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
+    little-plugger (1.1.3)
+    logging (2.0.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
     lumberjack (1.0.9)
+    memoist (0.12.0)
     metaclass (0.0.4)
     metadata-json-lint (0.0.6)
       json
       spdx-licenses (~> 1.0)
     method_source (0.8.2)
-    mime-types (2.4.3)
+    mime-types (2.5)
     mini_portile (0.6.2)
-    minitest (5.5.1)
+    minitest (5.6.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     multipart-post (2.0.0)
     nenv (0.2.0)
     net-http-persistent (2.9.4)
@@ -210,32 +232,31 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    netrc (0.10.2)
+    netrc (0.10.3)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    notiffany (0.0.3)
+    notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
     pry (0.9.12.6)
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    puppet (3.7.4)
+    puppet (3.7.5)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
-    puppet-blacksmith (3.1.1)
+    puppet-blacksmith (3.3.1)
       puppet (>= 2.7.16)
       rest-client
     puppet-lint (1.1.0)
-    puppet-syntax (1.4.1)
+    puppet-syntax (2.0.0)
       rake
-    puppetlabs_spec_helper (0.8.2)
+    puppetlabs_spec_helper (0.10.2)
       mocha
       puppet-lint
       puppet-syntax
       rake
-      rspec
       rspec-puppet
     pusher-client (0.6.0)
       json
@@ -248,27 +269,35 @@ GEM
       builder
       nokogiri (>= 1.4.1)
       trollop
-    rest-client (1.7.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     retriable (1.4.1)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-its (1.0.1)
-      rspec-core (>= 2.99.0.beta1)
-      rspec-expectations (>= 2.99.0.beta1)
-    rspec-mocks (2.99.3)
-    serverspec (1.16.0)
-      highline
-      net-ssh
-      rspec (~> 2.99)
+    rspec (3.2.0)
+      rspec-core (~> 3.2.0)
+      rspec-expectations (~> 3.2.0)
+      rspec-mocks (~> 3.2.0)
+    rspec-core (3.2.3)
+      rspec-support (~> 3.2.0)
+    rspec-expectations (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.2.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.2.0)
+    rspec-puppet (2.1.0)
+      rspec
+    rspec-support (3.2.2)
+    rsync (1.0.9)
+    serverspec (2.14.1)
+      multi_json
+      rspec (~> 3.0)
       rspec-its
-      specinfra (~> 1.27)
+      specinfra (~> 2.25)
     shellany (0.0.1)
     signet (0.6.0)
       addressable (~> 2.3)
@@ -279,12 +308,14 @@ GEM
     slop (3.6.0)
     spdx-licenses (1.0.0)
       json
-    specinfra (1.27.5)
+    specinfra (2.30.1)
+      net-scp
+      net-ssh
     thor (0.19.1)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     timers (4.0.1)
       hitimes
-    travis (1.7.5)
+    travis (1.7.6)
       addressable (~> 2.3)
       backports
       faraday (~> 0.9)
@@ -297,16 +328,17 @@ GEM
       typhoeus (~> 0.6, >= 0.6.8)
     travis-lint (2.0.0)
       json
-    trollop (2.1.1)
+    trollop (2.1.2)
     typhoeus (0.7.1)
       ethon (>= 0.7.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.1)
     vagrant-wrapper (2.0.2)
-    websocket (1.2.1)
+    websocket (1.2.2)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -324,7 +356,8 @@ DEPENDENCIES
   puppet-syntax
   puppetlabs_spec_helper
   rake
-  rspec-puppet!
+  rspec-puppet
   travis
   travis-lint
   vagrant-wrapper
+  yard

--- a/README.markdown
+++ b/README.markdown
@@ -8,19 +8,18 @@ By default, this module will install the Oracle VirtualBox yum/apt repo, install
 
 This module is tested with:
 
-- CentOS 5.10
-- CentOS 6.5
+- CentOS 5.11
+- CentOS 6.6
 - CentOS 7.0
 - Debian 6.0.7
 - Debian 7.3
 - Ubuntu 10.04
 - Ubuntu 12.04
 - Ubuntu 14.04
-- OpenSuSE 13.1
 
 It may work on other distros and OS versions, but these are the versions that we're targeting. If you wish to see another distro/version added to this list, so would we! PRs are welcome :)
 
-This module is tested with the latest version of Puppet 2.7 and all minor versions of Puppet 3; all Puppet supported versions of Ruby are included in the test matrix. It is also tested with the future parser in the latest release of Puppet. If you're interested in the testing matrix, please have a look at the `.travis.yml` file in the root of the module.
+This module is tested with the latest version of Puppet 2.7 as well as all minor versions of Puppet 3 and Puppet 4; all Puppet supported versions of Ruby are included in the test matrix. If you're interested in the testing matrix, please have a look at the `.travis.yml` file in the root of the module.
 
 ## Usage
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 This module installs VirtualBox on a Linux host using the official repositories or custom defined repositories. By default, this module will also configure the kernel modules required to run VirtualBox.
 
-By default, this module will install the Oracle VirtualBox yum/apt repo (see the [Note for Debian/Ubuntu Users using Puppet < 3.4.0](#Note for Debian/Ubuntu Users using Puppet < 3.4.0) below), install the VirtualBox package, and build the VirtualBox kernel modules. You can define a custom package name and/or version, you can also opt to not manage the repositories with this module. Because of the strange convention Oracle has opted to use for versioning VirtualBox, if you set a custom package name, the `version` parameter will be ignored. If you wish to define a package version with a custom package name, you must use the `package_ensure` parameter.
+By default, this module will install the Oracle VirtualBox yum/apt repo (see the [Note for Debian/Ubuntu Users using Puppet < 3.5.0](#note-for-debianubuntu-users-using-puppet--350) below), install the VirtualBox package, and build the VirtualBox kernel modules. You can define a custom package name and/or version, you can also opt to not manage the repositories with this module. Because of the strange convention Oracle has opted to use for versioning VirtualBox, if you set a custom package name, the `version` parameter will be ignored. If you wish to define a package version with a custom package name, you must use the `package_ensure` parameter.
 
 ## Support
 
@@ -76,9 +76,9 @@ There's a defined type to install an Extension Pack. I'm not aware of any extens
 
 This will download the extension pack, check to make sure the downloaded file matches the expected md5sum, then install the extension pack to `/usr/lib/virtualbox/ExtensionPacks`.
 
-## Note for Debian/Ubuntu Users using Puppet < 3.4.0
+## Note for Debian/Ubuntu Users using Puppet < 3.5.0
 
-This module depends on `puppetlabs/apt` >= 2.0.0 which has dropped support for Puppet < 3.4.0. While this module is still compatible with Puppet 2.7 and above, Debian/Ubuntu users on Puppet < 3.4.0 will no longer be able to manage the VirtualBox repository with this module. The default `manage_repo` setting for Debian/Ubuntu with Puppet < 3.4.0 is `false`, but remains `true` for all other `puppetversion` and `operatingsystemversion` combinations. Unfortunately, I am not able to express this nuance in the module metadata, so these users will need to work around the dependency resolution with `puppet module`. I apologize for the inconvenience.
+This module depends on `puppetlabs/apt` >= 2.0.0 which has dropped support for Puppet < 3.5.0. While this module is still compatible with Puppet 2.7 and above, Debian/Ubuntu users on Puppet < 3.5.0 will no longer be able to manage the VirtualBox repository with this module. The default `manage_repo` setting for Debian/Ubuntu with Puppet < 3.5.0 is `false`, but remains `true` for all other `puppetversion` and `operatingsystemversion` combinations. Unfortunately, I am not able to express this nuance in the module metadata, so these users will need to work around the dependency resolution with `puppet module`. I apologize for the inconvenience.
 
 ## Development
 

--- a/README.markdown
+++ b/README.markdown
@@ -78,7 +78,7 @@ This will download the extension pack, check to make sure the downloaded file ma
 
 ## Note for Debian/Ubuntu Users using Puppet < 3.5.0
 
-This module depends on `puppetlabs/apt` >= 2.0.0 which has dropped support for Puppet < 3.5.0. While this module is still compatible with Puppet 2.7 and above, Debian/Ubuntu users on Puppet < 3.5.0 will no longer be able to manage the VirtualBox repository with this module. The default `manage_repo` setting for Debian/Ubuntu with Puppet < 3.5.0 is `false`, but remains `true` for all other `puppetversion` and `operatingsystemversion` combinations. Unfortunately, I am not able to express this nuance in the module metadata, so these users will need to work around the dependency resolution with `puppet module`. I apologize for the inconvenience.
+This module depends on `puppetlabs/apt` >= 2.0.0 which has dropped support for Puppet < 3.5.0. While this module is still compatible with Puppet 2.7 and above, Debian/Ubuntu users on Puppet < 3.5.0 will no longer be able to manage the VirtualBox repository with this module. The default `manage_repo` setting for Debian/Ubuntu with Puppet < 3.5.0 is `false`, but remains `true` for all other `puppetversion` and `operatingsystemversion` combinations. Unfortunately, I am not able to express this nuance in the module metadata, so these users will need to work around the dependency resolution in the `puppet module` tool. I apologize for the inconvenience.
 
 ## Development
 

--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 
 This module installs VirtualBox on a Linux host using the official repositories or custom defined repositories. By default, this module will also configure the kernel modules required to run VirtualBox.
 
-By default, this module will install the Oracle VirtualBox yum/apt repo, install the VirtualBox package, and build the VirtualBox kernel modules. You can define a custom package name and/or version, you can also opt to not manage the repositories with this module. Because of the strange convention Oracle has opted to use for versioning VirtualBox, if you set a custom package name, the `version` parameter will be ignored. If you wish to define a package version with a custom package name, you must use the `package_ensure` parameter.
+By default, this module will install the Oracle VirtualBox yum/apt repo (see the [Note for Debian/Ubuntu Users using Puppet < 3.4.0](#Note for Debian/Ubuntu Users using Puppet < 3.4.0) below), install the VirtualBox package, and build the VirtualBox kernel modules. You can define a custom package name and/or version, you can also opt to not manage the repositories with this module. Because of the strange convention Oracle has opted to use for versioning VirtualBox, if you set a custom package name, the `version` parameter will be ignored. If you wish to define a package version with a custom package name, you must use the `package_ensure` parameter.
 
 ## Support
 
@@ -75,6 +75,10 @@ There's a defined type to install an Extension Pack. I'm not aware of any extens
     }
 
 This will download the extension pack, check to make sure the downloaded file matches the expected md5sum, then install the extension pack to `/usr/lib/virtualbox/ExtensionPacks`.
+
+## Note for Debian/Ubuntu Users using Puppet < 3.4.0
+
+This module depends on `puppetlabs/apt` >= 2.0.0 which has dropped support for Puppet < 3.4.0. While this module is still compatible with Puppet 2.7 and above, Debian/Ubuntu users on Puppet < 3.4.0 will no longer be able to manage the VirtualBox repository with this module. The default `manage_repo` setting for Debian/Ubuntu with Puppet < 3.4.0 is `false`, but remains `true` for all other `puppetversion` and `operatingsystemversion` combinations. Unfortunately, I am not able to express this nuance in the module metadata, so these users will need to work around the dependency resolution with `puppet module`. I apologize for the inconvenience.
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,9 +14,9 @@
 # [*manage_repo*]
 #   Should this module manage the package repository?
 #   Defaults to true
-# [*manage_epel*]
-#   On applicable platforms, should this module manage the EPEL repository
-#   when `manage_kernel` is set to true?
+# [*manage_ext_repo*]
+#   On applicable platforms, should this module manage the external dependency
+#   repository when `manage_kernel` is set to true?
 #   Defaults to true
 # [*manage_package*]
 #   Should this module manage the package?
@@ -37,7 +37,7 @@ class virtualbox (
   $version              = $virtualbox::params::version,
   $package_ensure       = $virtualbox::params::package_ensure,
   $manage_repo          = $virtualbox::params::manage_repo,
-  $manage_epel          = $virtualbox::params::manage_epel,
+  $manage_ext_repo      = $virtualbox::params::manage_ext_repo,
   $manage_package       = $virtualbox::params::manage_package,
   $manage_kernel        = $virtualbox::params::manage_kernel,
   $vboxdrv_dependencies = $virtualbox::params::vboxdrv_dependencies,
@@ -45,7 +45,7 @@ class virtualbox (
 ) inherits virtualbox::params {
 
   validate_bool($manage_repo)
-  validate_bool($manage_epel)
+  validate_bool($manage_ext_repo)
   validate_bool($manage_package)
   validate_bool($manage_kernel)
   validate_string($package_name)
@@ -57,7 +57,7 @@ class virtualbox (
     Class['virtualbox::install'] -> class { 'virtualbox::kernel': }
 
     if $::osfamily == 'RedHat' {
-      if $manage_epel {
+      if $manage_ext_repo {
         include epel
         Class['epel'] -> Class['virtualbox::kernel']
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,10 @@
 # [*manage_repo*]
 #   Should this module manage the package repository?
 #   Defaults to true
+# [*manage_epel*]
+#   On applicable platforms, should this module manage the EPEL repository
+#   when `manage_kernel` is set to true?
+#   Defaults to true
 # [*manage_package*]
 #   Should this module manage the package?
 #   Defaults to true

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,14 +28,16 @@ class virtualbox::install (
 
         include apt
 
+        apt::key { '98AB5139':
+          ensure => present,
+          source => 'https://www.virtualbox.org/download/oracle_vbox.asc',
+        }
+
         apt::source { 'virtualbox':
-          location          => 'http://download.virtualbox.org/virtualbox/debian',
-          release           => $::lsbdistcodename,
-          repos             => $apt_repos,
-          required_packages => 'debian-keyring debian-archive-keyring',
-          key               => '98AB5139',
-          key_source        => 'https://www.virtualbox.org/download/oracle_vbox.asc',
-          include_src       => false,
+          location => 'http://download.virtualbox.org/virtualbox/debian',
+          release  => $::lsbdistcodename,
+          repos    => $apt_repos,
+          require  => Apt::Key['98AB5139'],
         }
 
         if $manage_package {
@@ -62,8 +64,12 @@ class virtualbox::install (
       case $::operatingsystem {
         'OpenSuSE': {
           if $manage_repo {
+            if $::operatingsystemrelease !~ /^(12.3|11)/ {
+              fail('Oracle only supports OpenSuSE 11 and 12.3! You need to manage your own repo.')
+            }
+
             zypprepo { 'virtualbox':
-              baseurl     => "http://download.virtualbox.org/virtualbox/rpm/opensuse/${::lsbdistrelease}",
+              baseurl     => "http://download.virtualbox.org/virtualbox/rpm/opensuse/${::operatingsystemrelease}",
               enabled     => 1,
               autorefresh => 1,
               name        => 'Oracle Virtual Box',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,7 +35,7 @@ class virtualbox::params {
       ]
     }
     'Suse': {
-      warn('Careful! Support for SuSE is experimental at best.')
+      warning('Careful! Support for SuSE is experimental at best.')
 
       $package_name = 'VirtualBox'
       $vboxdrv_dependencies = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,16 +4,23 @@
 # It sets variables according to platform
 #
 class virtualbox::params {
-  $version = '4.3'
-  $manage_kernel = true
-  $manage_package = true
-  $manage_repo = true
-  $manage_epel = true
-  $package_ensure = present
+  $manage_ext_repo = true
 
   case $::osfamily {
     'Debian': {
+      $version = '4.3'
+      $manage_kernel = true
+      $manage_package = true
+      $package_ensure = present
       $package_name = 'virtualbox'
+
+      if versioncmp($::puppetversion, '3.4.0') == '-1' {
+        notice "The default behavior for the manage_repo parameter has changed for ${::puppetversion} on Debian/Ubuntu systems. You must now manage Apt repos separate from the virtualbox module. See the README.md for more details." # lint:ignore:80chars
+        $manage_repo = false
+      } else {
+        $manage_repo = true
+      }
+
       $vboxdrv_dependencies = [
         'dkms',
         "linux-headers-${::kernelrelease}",
@@ -21,6 +28,11 @@ class virtualbox::params {
       ]
     }
     'RedHat': {
+      $version = '4.3'
+      $manage_kernel = true
+      $manage_package = true
+      $manage_repo = true
+      $package_ensure = present
       $package_name = 'VirtualBox'
       $vboxdrv_dependencies = [
         'gcc',
@@ -36,7 +48,11 @@ class virtualbox::params {
     }
     'Suse': {
       warning('Careful! Support for SuSE is experimental at best.')
-
+      $version = '4.3'
+      $manage_kernel = true
+      $manage_package = true
+      $manage_repo = true
+      $package_ensure = present
       $package_name = 'VirtualBox'
       $vboxdrv_dependencies = [
         'gcc',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class virtualbox::params {
       $package_ensure = present
       $package_name = 'virtualbox'
 
-      if versioncmp($::puppetversion, '3.4.0') == '-1' {
+      if versioncmp($::puppetversion, '3.5.0') == -1 {
         notice "The default behavior for the manage_repo parameter has changed for ${::puppetversion} on Debian/Ubuntu systems. You must now manage Apt repos separate from the virtualbox module. See the README.md for more details." # lint:ignore:80chars
         $manage_repo = false
       } else {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -35,6 +35,8 @@ class virtualbox::params {
       ]
     }
     'Suse': {
+      warn('Careful! Support for SuSE is experimental at best.')
+
       $package_name = 'VirtualBox'
       $vboxdrv_dependencies = [
         'gcc',

--- a/metadata.json
+++ b/metadata.json
@@ -13,12 +13,6 @@
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "OpenSuSE",
-      "operatingsystemrelease": [
-        "13.1"
-      ]
-    },
-    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "5",
@@ -52,12 +46,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.4.0"
     }
   ],
   "dependencies": [
@@ -67,19 +57,15 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "version_requirement": ">=2.0.0 <3.0.0"
     },
     {
       "name": "stahnma/epel",
       "version_requirement": ">=0.0.6 <2.0.0"
     },
     {
-      "name": "darin/zypprepo",
-      "version_requirement": ">=1.0.0 <2.0.0"
-    },
-    {
       "name": "camptocamp/archive",
-      "version_requirement": ">=0.1.0"
+      "version_requirement": ">=0.1.0 <1.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -47,7 +47,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.4.0"
+      "version_requirement": ">= 2.7.26"
     }
   ],
   "dependencies": [

--- a/spec/acceptance/nodesets/centos-510-x64.yml
+++ b/spec/acceptance/nodesets/centos-510-x64.yml
@@ -4,7 +4,8 @@ HOSTS:
       - master
     platform: el-5-x86_64
     box: centos-510-x64-virtualbox-puppet
-    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-510-x64-virtualbox-puppet.box 
-    hypervisor: vagrant
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-510-x64-virtualbox-puppet.box
+    hypervisor: vagrant_virtualbox
 CONFIG:
+  log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/centos-511-x64.yml
+++ b/spec/acceptance/nodesets/centos-511-x64.yml
@@ -1,9 +1,9 @@
 HOSTS:
-  centos-7-x64:
+  centos-511-x64:
     roles:
       - master
-    platform: el-7-x86_64
-    box: puppetlabs/centos-7.0-64-nocm
+    platform: el-5-x86_64
+    box: puppetlabs/centos-5.11-64-nocm
     hypervisor: vagrant_virtualbox
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/centos-66-x64.yml
+++ b/spec/acceptance/nodesets/centos-66-x64.yml
@@ -1,10 +1,9 @@
 HOSTS:
-  centos-65-x64:
+  centos-66-x64:
     roles:
       - master
     platform: el-6-x86_64
-    box: centos-65-x64-nocm
-    box_url: http://puppet-vagrant-boxes.puppetlabs.com/centos-65-x64-virtualbox-nocm.box
+    box: puppetlabs/centos-6.6-64-nocm
     hypervisor: vagrant_virtualbox
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/debian-607-x64.yml
+++ b/spec/acceptance/nodesets/debian-607-x64.yml
@@ -3,8 +3,9 @@ HOSTS:
     roles:
       - master
     platform: debian-6-amd64
-    box : debian-607-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210-nocm.box
-    hypervisor : vagrant
+    box: debian-607-x64-vbox4210-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/debian-607-x64-vbox4210-nocm.box
+    hypervisor: vagrant_virtualbox
 CONFIG:
+  log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/debian-73-x64.yml
+++ b/spec/acceptance/nodesets/debian-73-x64.yml
@@ -3,9 +3,9 @@ HOSTS:
     roles:
       - master
     platform: debian-7-amd64
-    box : debian-73-x64-virtualbox-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
-    hypervisor : vagrant
+    box: debian-73-x64-virtualbox-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/debian-73-x64-virtualbox-nocm.box
+    hypervisor: vagrant_virtualbox
 CONFIG:
-  log_level: debug
+  log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -5,8 +5,7 @@ HOSTS:
     platform: ubuntu-server-12.04-amd64
     box: ubuntu-server-12042-x64-vbox4210-nocm
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
-    hypervisor: vagrant
-
+    hypervisor: vagrant_virtualbox
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/opensuse-131-x64.yml
+++ b/spec/acceptance/nodesets/opensuse-131-x64.yml
@@ -1,9 +1,9 @@
 HOSTS:
-  centos-7-x64:
+  opensuse-131-x64:
     roles:
       - master
-    platform: el-7-x86_64
-    box: puppetlabs/centos-7.0-64-nocm
+    platform: sles-131-x86_64
+    box: webhippie/opensuse-13.1
     hypervisor: vagrant_virtualbox
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/ubuntu-server-1004-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1004-x64.yml
@@ -3,8 +3,9 @@ HOSTS:
     roles:
       - master
     platform: ubuntu-10.04-amd64
-    box : ubuntu-server-10044-x64-vbox4210-nocm
-    box_url : http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210-nocm.box
-    hypervisor : vagrant
+    box: ubuntu-server-10044-x64-vbox4210-nocm
+    box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-10044-x64-vbox4210-nocm.box
+    hypervisor: vagrant_virtualbox
 CONFIG:
-  type: git
+  log_level: verbose
+  type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-12042-x64.yml
@@ -5,7 +5,7 @@ HOSTS:
     platform: ubuntu-server-12.04-amd64
     box: ubuntu-server-12042-x64-vbox4210-nocm
     box_url: http://puppet-vagrant-boxes.puppetlabs.com/ubuntu-server-12042-x64-vbox4210-nocm.box
-    hypervisor: vagrant
+    hypervisor: vagrant_virtualbox
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-server-1404-x64.yml
@@ -4,9 +4,7 @@ HOSTS:
       - master
     platform: ubuntu-server-14.04-amd64
     box: puppetlabs/ubuntu-14.04-64-nocm
-    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
-    hypervisor: vagrant
-
+    hypervisor: vagrant_virtualbox
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/acceptance/virtualbox_extpack_spec.rb
+++ b/spec/acceptance/virtualbox_extpack_spec.rb
@@ -13,18 +13,18 @@ describe 'virtualbox extpack' do
         follow_redirects => true,
       }
       EOS
-    
+
       apply_manifest(pp, :catch_failures => true)
       apply_manifest(pp, :catch_changes => true)
     end
-  
+
     describe file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') do
       it { should be_directory }
     end
-    
+
     describe file('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz') do
       it { should be_file }
-      it { should match_md5checksum '4b7546ddf94308901b629865c54d5840' }
+      its(:md5sum) { should eq '4b7546ddf94308901b629865c54d5840' }
     end
 
     describe command("VBoxManage list extpacks") do
@@ -32,7 +32,7 @@ describe 'virtualbox extpack' do
       its(:stdout) { should match /Extension Packs: 1/ }
     end
   end
-  
+
   context 'uninstall extpack' do
     it 'should be idempotent' do
       pp1 = <<-EOS
@@ -45,7 +45,7 @@ describe 'virtualbox extpack' do
         follow_redirects => true,
       }
       EOS
-      
+
       pp2 = <<-EOS
       include virtualbox
 
@@ -56,7 +56,7 @@ describe 'virtualbox extpack' do
         follow_redirects => true,
       }
       EOS
-    
+
       apply_manifest(pp1, :catch_failures => true)
       apply_manifest(pp2, :catch_failures => true)
       apply_manifest(pp2, :catch_changes => true)
@@ -65,11 +65,11 @@ describe 'virtualbox extpack' do
     describe file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') do
       it { should_not be_directory }
     end
-    
+
     describe file('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz') do
       it { should_not be_file }
     end
-    
+
     describe command("VBoxManage list extpacks") do
       its(:exit_status) { should eq 0 }
       its(:stdout) { should match /Extension Packs: 0/ }

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -26,13 +26,13 @@ describe 'virtualbox', :type => :class do
       # Debian specific stuff
       #
       if facts[:osfamily] == 'Debian'
-        if Puppet::Util::Package.versioncmp(facts[:puppetversion], '3.4.0') == -1
-          context 'with $::puppetversion < 3.4.0' do
-            let(:facts) {facts.merge({:puppetversion => '3.3.0'})}
-            it { should_not contain_class('apt') }
-            it { should_not contain_apt__source('virtualbox') }
-          end
-        else
+        context 'with $::puppetversion < 3.5.0' do
+          let(:facts) {facts.merge({:puppetversion => '3.4.3'})}
+          it { should_not contain_class('apt') }
+          it { should_not contain_apt__source('virtualbox') }
+        end
+
+        unless Puppet::Util::Package.versioncmp(facts[:puppetversion], '3.5.0') == -1
           it { should contain_class('apt') }
           it { should contain_apt__source('virtualbox').with_location('http://download.virtualbox.org/virtualbox/debian') }
 
@@ -49,12 +49,6 @@ describe 'virtualbox', :type => :class do
 
           context 'when managing the package and the repository' do
             it { should contain_apt__source('virtualbox').that_comes_before('Package[virtualbox]') }
-          end
-
-          context 'with $::puppetversion < 3.4.0' do
-            let(:facts) {facts.merge({:puppetversion => '3.3.0'})}
-            it { should_not contain_class('apt') }
-            it { should_not contain_apt__source('virtualbox') }
           end
         end
       end

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -104,7 +104,7 @@ describe 'virtualbox', :type => :class do
         context 'with manage_repo => true on an unsupported version' do
           let(:facts) {facts.merge({:operatingsystemrelease => '13.1' })}
           let(:params) {{ 'manage_repo' => true }}
-          it { should raise_error(Puppet::Error, /manage your own repo/) }
+          it { is_expected.to raise_error(Puppet::Error, /manage your own repo/) }
         end
       end
 

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -9,7 +9,7 @@ describe 'virtualbox', :type => :class do
       :lsbdistid => 'Ubuntu',
       :lsbdistcodename => 'trusty',
       :operatingsystemrelease => '14.04',
-      :puppetversion => '4.0.0'
+      :puppetversion => Puppet.version
     }, {
       :osfamily => 'RedHat',
       :operatingsystem => "RedHat",
@@ -26,7 +26,7 @@ describe 'virtualbox', :type => :class do
       # Debian specific stuff
       #
       if facts[:osfamily] == 'Debian'
-        if Puppet::Util::Package.versioncmp(Puppet.version, '3.4.0') == -1
+        if Puppet::Util::Package.versioncmp(facts[:puppetversion], '3.4.0') == -1
           context 'with $::puppetversion < 3.4.0' do
             let(:facts) {facts.merge({:puppetversion => '3.3.0'})}
             it { should_not contain_class('apt') }

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -89,7 +89,7 @@ describe 'virtualbox', :type => :class do
         context 'with manage_repo => true on an unsupported version' do
           let(:facts) {facts.merge({:operatingsystemrelease => '13.1' })}
           let(:params) {{ 'manage_repo' => true }}
-          it { is_expected.to raise_error(Puppet::Error, /manage your own repo/) }
+          it { should raise_error(Puppet::Error, /manage your own repo/) }
         end
       end
 

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -15,7 +15,7 @@ describe 'virtualbox', :type => :class do
     }, {
       :osfamily => 'Suse',
       :operatingsystem => "OpenSuSE",
-      :lsbdistrelease => '13.1',
+      :operatingsystemrelease => '12.3',
     }
   ].each do |facts|
     context "on #{facts[:osfamily]}" do
@@ -70,7 +70,7 @@ describe 'virtualbox', :type => :class do
       # Suse specific stuff
       #
       if facts[:osfamily] == 'Suse'
-        it { should contain_zypprepo('virtualbox').with_baseurl('http://download.virtualbox.org/virtualbox/rpm/opensuse/13.1') }
+        it { should contain_zypprepo('virtualbox').with_baseurl('http://download.virtualbox.org/virtualbox/rpm/opensuse/12.3') }
 
         context 'with a custom version' do
           let(:params) {{ 'version' => '4.2' }}
@@ -85,14 +85,17 @@ describe 'virtualbox', :type => :class do
         context 'when managing the package and the repository' do
           it { should contain_zypprepo('virtualbox').that_comes_before('Package[virtualbox]') }
         end
+
+        context 'with manage_repo => true on an unsupported version' do
+          let(:facts) {facts.merge({:operatingsystemrelease => '13.1' })}
+          let(:params) {{ 'manage_repo' => true }}
+          it { is_expected.to raise_error(Puppet::Error, /manage your own repo/) }
+        end
       end
 
       # Non $::osfamily specific stuff
       #
       it { should compile.with_all_deps }
-      #it { should contain_class('virtualbox::install').that_comes_before('virtualbox::config') }
-      #it { should contain_class('virtualbox::service').that_subscribes_to('virtualbox::config') }
-      #it { should contain_class('virtualbox::config') }
 
       it { should contain_package('virtualbox') }
 

--- a/spec/defines/virtualbox__extpack_spec.rb
+++ b/spec/defines/virtualbox__extpack_spec.rb
@@ -46,10 +46,10 @@ describe 'virtualbox::extpack' do
     it { should contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_type('md5') }
     it { should contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
   end
-  
-  context 'with bad checksum type' do
-    let(:params) {sane_defaults.merge({ :checksum_type => 'invalid'})}
 
-    it { expect { should contain_archive('Oracle_VM_VirtualBox_Extension_Pack') }.to raise_error(Puppet::Error, /does not match/) }
+  context 'with bad checksum type' do
+    let(:params) {sane_defaults.merge({ :checksum_type => 'invalid' })}
+
+    it { is_expected.to raise_error(Puppet::Error, /does not match/) }
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -3,7 +3,13 @@ require 'pry'
 
 hosts.each do |host|
   # Install Puppet
-  install_puppet
+  if host['platform'] =~ /sles/
+    host.install_package('puppet')
+    host.install_package('facter')
+  else
+    install_puppet :default_action => 'gem_install'
+  end
+
   on host, "mkdir -p #{host['distmoduledir']}"
 end
 


### PR DESCRIPTION
This also updates the puppetlabs/apt dependency, adds provisional support for OpenSuSE, and a few other bugfixes. See CHANGELOG.md for more details.