### PR TITLE
add support for $::operatingsystem == Fedora

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -47,9 +47,14 @@ class virtualbox::install (
     }
     'RedHat': {
       if $manage_repo {
+        $platform = $::operatingsystem ? {
+          'Fedora' => 'fedora',
+          default  => 'el',
+        }
+
         yumrepo { 'virtualbox':
           descr    => 'Oracle Linux / RHEL / CentOS-$releasever / $basearch - VirtualBox',
-          baseurl  => 'http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch',
+          baseurl  => "http://download.virtualbox.org/virtualbox/rpm/${platform}/\$releasever/\$basearch",
           gpgkey   => 'https://www.virtualbox.org/download/oracle_vbox.asc',
           gpgcheck => 1,
           enabled  => 1,

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -15,6 +15,10 @@ describe 'virtualbox', :type => :class do
       :operatingsystem => "RedHat",
       :operatingsystemrelease => '6.5',
     }, {
+      :osfamily => 'RedHat',
+      :operatingsystem => 'Fedora',
+      :operatingsystemrelease => '22',
+    }, {
       :osfamily => 'Suse',
       :operatingsystem => "OpenSuSE",
       :operatingsystemrelease => '12.3',
@@ -56,7 +60,12 @@ describe 'virtualbox', :type => :class do
       # RedHat specific stuff
       #
       if facts[:osfamily] == 'RedHat'
-        it { should contain_yumrepo('virtualbox').with_baseurl('http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox.asc') }
+        case facts[:operatingsystem]
+        when 'Fedora'
+          it { should contain_yumrepo('virtualbox').with_baseurl('http://download.virtualbox.org/virtualbox/rpm/fedora/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox.asc') }
+        else
+          it { should contain_yumrepo('virtualbox').with_baseurl('http://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox.asc') }
+        end
 
         context 'with a custom version' do
           let(:params) {{ 'version' => '4.2' }}


### PR DESCRIPTION
The yumrepo URL for fedora 18+ is different than what is used for el packages.