### PR TITLE
Any interest in replacing camptocamp/archive with puppet-community/archive?

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
       ref: '2.1.0'
     epel: "https://github.com/stahnma/puppet-module-epel.git"
-    archive: "https://github.com/camptocamp/puppet-archive.git"
+    archive: "https://github.com/puppet-community/puppet-archive.git"
     zypprepo: "https://github.com/deadpoint/puppet-zypprepo.git"
   symlinks:
     virtualbox: "#{source_dir}"

--- a/spec/defines/virtualbox__extpack_spec.rb
+++ b/spec/defines/virtualbox__extpack_spec.rb
@@ -13,38 +13,24 @@ describe 'virtualbox::extpack' do
   sane_defaults = {
     :ensure           => 'present',
     :source           => 'http://server.example.com/extpack.vbox-extpack',
-    :checksum_string  => 'd41d8cd98f00b204e9800998ecf8427e',
+    :checksum		=> 'd41d8cd98f00b204e9800998ecf8427e',
   }
 
   context 'with defaults' do
     let(:params) {sane_defaults}
 
     it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum(true) }
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_string('d41d8cd98f00b204e9800998ecf8427e') }
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_type('md5') }
+    it { is_expected.to contain_archive('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum('d41d8cd98f00b204e9800998ecf8427e') }
+    it { is_expected.to contain_archive('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum_type('md5') }
     it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
-    it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').that_requires('Archive::Download[Oracle_VM_VirtualBox_Extension_Pack.tgz]') }
+    it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').that_requires('Archive[/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack.tgz]') }
 
   end
 
   context 'with ensure => absent' do
     let(:params) {sane_defaults.merge({:ensure => 'absent'})}
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_ensure('absent') }
+    it { is_expected.to contain_archive('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_ensure('absent') }
     it { is_expected.to contain_file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack').with_ensure('absent') }
-  end
-
-  context 'with $verify_checksum => false' do
-    let(:params) {sane_defaults.merge({
-      :verify_checksum  => false,
-      :checksum_type    => 'sha1',
-    })}
-
-    it { is_expected.to compile.with_all_deps }
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum(false) }
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_string(nil) }
-    it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_type('md5') }
-    it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
   end
 
   context 'with bad checksum type' do


### PR DESCRIPTION
I'd like to use another module to install/manage Wildfly but it utilizes puppet-community/archive.  I also use the virtualbox module and unfortunately the two different archive modules are conflicting.

Any interest in switching from camptocamp to puppet-community/archive?