### PR TITLE
Reorder vboxdrv dependencies for RedHat systems.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -39,9 +39,9 @@ class virtualbox::params {
         'gcc',
         'make',
         'patch',
-        'dkms',
         'kernel-headers',
         'kernel-devel',
+        'dkms',
         'binutils',
         'glibc-headers',
         'glibc-devel'


### PR DESCRIPTION
If 'dkms' package is installed before kernel-devel, Yum may satisfy the dependencies by installing a different kernel source (eg kernel-debug-devel).
This commit reorders the dependency list to ensure the correct kernel source is selected.