### PR TITLE
Determine correct path for vboxdrv.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,12 @@ class virtualbox (
     warning 'Support for Puppet < 3.0 is deprecated. Version 2.0 of this module will only support Puppet >= 4.0' # lint:ignore:80chars
   }
 
+  if versioncmp($version, '5.0') == -1 {
+    $vboxdrv_command = '/etc/init.d/vboxdrv'
+  } else {
+    $vboxdrv_command = '/usr/lib/virtualbox/vboxdrv.sh'
+  }
+
   validate_bool($manage_repo)
   validate_bool($manage_ext_repo)
   validate_bool($manage_package)

--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -6,12 +6,14 @@
 #
 class virtualbox::kernel (
   $manage_repo          = $virtualbox::manage_repo,
-  $vboxdrv_dependencies = $virtualbox::vboxdrv_dependencies
+  $vboxdrv_dependencies = $virtualbox::vboxdrv_dependencies,
+  $vboxdrv_command      = $virtualbox::vboxdrv_command
 ) {
 
   ensure_packages($vboxdrv_dependencies)
 
-  exec { '/etc/init.d/vboxdrv setup':
+  exec { 'vboxdrv':
+    command     => "${vboxdrv_command} setup",
     unless      => '/sbin/lsmod | grep vboxdrv',
     environment => 'KERN_DIR=/usr/src/kernels/`uname -r`',
     require     => Package[$vboxdrv_dependencies],


### PR DESCRIPTION
From version 5 onwards, the path for the vboxdrv command has changed.
This commit determines the correct path to use based on the selected VirtualBox version.