### PR TITLE
Fixing https://github.com/danzilio/danzilio-virtualbox/issues/29

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,9 +10,7 @@ class virtualbox::install (
   $package_name   = $virtualbox::package_name,
   $manage_repo    = $virtualbox::manage_repo,
   $repo_proxy     = $virtualbox::repo_proxy,
-  $manage_package = $virtualbox::manage_package,
-  $apt_key_thumb  = $virtualbox::apt_key_thumb,
-  $apt_key_source = $virtualbox::apt_key_source
+  $manage_package = $virtualbox::manage_package
 ) {
 
   if $package_name == $::virtualbox::params::package_name {
@@ -33,6 +31,17 @@ class virtualbox::install (
 
         if $repo_proxy {
           warning('The $repo_proxy parameter is not implemented on Debian-like systems. Please use the $proxy parameter on the apt class. Ignoring.')
+        }
+
+        case $::lsbdistcodename {
+          /^(jessie|xenial)$/: {
+            $apt_key_thumb  = 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF'
+            $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
+          }
+          default: {
+            $apt_key_thumb  = '7B0FAB3A13B907435925D9C954422A4B98AB5139'
+            $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox.asc'
+          }
         }
 
         apt::key { $apt_key_thumb:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,7 +10,9 @@ class virtualbox::install (
   $package_name   = $virtualbox::package_name,
   $manage_repo    = $virtualbox::manage_repo,
   $repo_proxy     = $virtualbox::repo_proxy,
-  $manage_package = $virtualbox::manage_package
+  $manage_package = $virtualbox::manage_package,
+  $apt_key_thumb  = $virtualbox::apt_key_thumb,
+  $apt_key_source = $virtualbox::apt_key_source
 ) {
 
   if $package_name == $::virtualbox::params::package_name {
@@ -33,16 +35,16 @@ class virtualbox::install (
           warning('The $repo_proxy parameter is not implemented on Debian-like systems. Please use the $proxy parameter on the apt class. Ignoring.')
         }
 
-        apt::key { '7B0FAB3A13B907435925D9C954422A4B98AB5139':
+        apt::key { $apt_key_thumb:
           ensure => present,
-          source => 'https://www.virtualbox.org/download/oracle_vbox.asc',
+          source => $apt_key_source,
         }
 
         apt::source { 'virtualbox':
           location => 'http://download.virtualbox.org/virtualbox/debian',
           release  => $::lsbdistcodename,
           repos    => $apt_repos,
-          require  => Apt::Key['7B0FAB3A13B907435925D9C954422A4B98AB5139'],
+          require  => Apt::Key[ $apt_key_thumb ],
         }
 
         if $manage_package {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,8 +6,6 @@
 class virtualbox::params {
   $manage_ext_repo = true
   $repo_proxy      = undef
-  $apt_key_thumb   = undef
-  $apt_key_source  = undef
 
   case $::osfamily {
     'Debian': {
@@ -30,16 +28,6 @@ class virtualbox::params {
         'build-essential',
       ]
 
-      case $::lsbdistcodename {
-        /^(jessie|xenial)$/: {
-          $apt_key_thumb  = 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF'
-          $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
-        }
-        default: {
-          $apt_key_thumb  = '7B0FAB3A13B907435925D9C954422A4B98AB5139'
-          $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox.asc'
-        }
-      }
     }
     'RedHat': {
       $version = '5.0'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,17 @@ class virtualbox::params {
         "linux-headers-${::kernelrelease}",
         'build-essential',
       ]
+
+      case $::lsbdistcodename {
+        /^(jessie|xenial)$/: {
+          $apt_key_thumb  = 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF'
+          $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
+        }
+        default: {
+          $apt_key_thumb  = '7B0FAB3A13B907435925D9C954422A4B98AB5139'
+          $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox.asc'
+        }
+      }
     }
     'RedHat': {
       $version = '5.0'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,8 @@
 class virtualbox::params {
   $manage_ext_repo = true
   $repo_proxy      = undef
+  $apt_key_thumb   = undef
+  $apt_key_source  = undef
 
   case $::osfamily {
     'Debian': {


### PR DESCRIPTION
I've added two params:

apt_key_thumb (this is the thumbprint of the apt key)
apt_key_source (this is the location of the apt key)

In params.pp I've added a conditional to check lsbdistcodename and
assign values to the two new params accordingly.

Tested on:
Debian Jessie and Wheezy
Ubuntu Trusty and Xenial