### PR TITLE
Fix typo in test for  context 'when not managing the package'

### DIFF
--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -152,7 +152,7 @@ describe 'virtualbox', :type => :class do
 
       context 'when not managing the package' do
         let(:params) {{ 'manage_package' => false }}
-        it { is_expected.not_to contain_packge('virtualbox') }
+        it { is_expected.not_to contain_package('virtualbox') }
       end
 
       context 'with a custom package name and version' do


### PR DESCRIPTION
At least I think it was a typo - it was packge, but the original test would still pass as it was ensuring it wasn't present.